### PR TITLE
Update for 1.12 and 1.12.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,23 +13,23 @@ buildscript {
     }
 
     dependencies {
-        classpath 'net.minecraftforge.gradle:ForgeGradle:2.2-SNAPSHOT'
-        classpath 'org.spongepowered:mixingradle:0.4-SNAPSHOT'
+        classpath 'net.minecraftforge.gradle:ForgeGradle:2.3-SNAPSHOT'
+        classpath 'org.spongepowered:mixingradle:0.5-SNAPSHOT'
     }
 }
+
 apply plugin: 'net.minecraftforge.gradle.liteloader'
 apply plugin: 'org.spongepowered.mixin'
 
 group 'com.minelittlepony'
-version '1.0.3'
+version '1.0.4'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 minecraft {
-    version = '1.11.2'
-    // first snapshot for 1.11. Change to stable when possible.
-    mappings = 'snapshot_20161224'
+    version = '1.12'
+    mappings = 'snapshot_20170627'
     runDir = 'run'
     replace '@VERSION@', project.version
 }
@@ -45,6 +45,7 @@ litemod.json {
     description = 'Ah am a big pony!'
     mixinConfigs += 'bigpony.mixin.json'
 }
+
 mixin {
     defaultObfuscationEnv notch
 }
@@ -53,4 +54,3 @@ jar {
     from litemod.outputs
     from sourceSets.api.output
 }
-

--- a/build.gradle
+++ b/build.gradle
@@ -28,8 +28,8 @@ sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
 minecraft {
-    version = '1.12'
-    mappings = 'snapshot_20170627'
+    version = '1.12.1'
+    mappings = 'snapshot_20170804'
     runDir = 'run'
     replace '@VERSION@', project.version
 }

--- a/build.number
+++ b/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Sat Jan 07 15:24:46 EST 2017
-build.number=98
+#Tue Aug 29 16:40:44 PDT 2017
+build.number=118

--- a/src/main/java/com/minelittlepony/bigpony/mod/gui/GuiBigSettings.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/gui/GuiBigSettings.java
@@ -54,8 +54,8 @@ public class GuiBigSettings extends GuiScreen implements GuiResponder, FormatHel
     public void drawScreen(int mouseX, int mouseY, float partialTicks) {
         this.drawDefaultBackground();
         super.drawScreen(mouseX, mouseY, partialTicks);
-        this.drawCenteredString(this.fontRendererObj, "BigPony settings", width / 2, 10, -1);
-        this.drawCenteredString(this.fontRendererObj, "Camera Presets", 280, 25, -1);
+        this.drawCenteredString(this.fontRenderer, "BigPony settings", width / 2, 10, -1);
+        this.drawCenteredString(this.fontRenderer, "Camera Presets", 280, 25, -1);
     }
 
     @Override

--- a/src/main/resources/litemod.json
+++ b/src/main/resources/litemod.json
@@ -1,7 +1,7 @@
 {
   "name": "bigpony",
   "revision": 0,
-  "mcversion": "1.11",
+  "mcversion": "1.12",
   "mixinConfigs": [
     "bigpony.mixin.json"
   ]

--- a/src/main/resources/litemod.json
+++ b/src/main/resources/litemod.json
@@ -1,7 +1,7 @@
 {
   "name": "bigpony",
   "revision": 0,
-  "mcversion": "1.12",
+  "mcversion": "1.12.1",
   "mixinConfigs": [
     "bigpony.mixin.json"
   ]


### PR DESCRIPTION
- Updated forge, gradle, and sponge
- Renamed `net.minecraft.client.gui.FontRendererObj` to `net.minecraft.client.gui.FontRenderer`

Binaries can be found here:
[https://github.com/BitBlitObviMormon/BigPony/releases/tag/1.0.4](https://github.com/BitBlitObviMormon/BigPony/releases/tag/1.0.4
)