### PR TITLE
Fixed: Player's eye height is reset upon respawning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ### Gradle
 .gradle/
 build/
+run/
 
 ### JetBrains
 .idea/

--- a/src/main/java/com/minelittlepony/bigpony/mod/LiteModBigPony.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/LiteModBigPony.java
@@ -177,16 +177,16 @@ public class LiteModBigPony implements BigPony, InitCompleteListener, Tickable, 
     }
 
     private void updateHeightDistance() {
-		Minecraft mc = Minecraft.getMinecraft();
-		
+        Minecraft mc = Minecraft.getMinecraft();
+
         IEntityRenderer er = (IEntityRenderer) mc.entityRenderer;
         er.setThirdPersonDistance(distance);
         IEntityPlayer ep = (IEntityPlayer) mc.player;
         ep.setEyeHeight(height);
-        
+
         if (mc.isIntegratedServerRunning()) {
-        	IEntityPlayer mplayer = (IEntityPlayer) mc.getIntegratedServer().getPlayerList().getPlayerByUUID(mc.player.getUniqueID());
-        	if (mplayer != null) mplayer.setEyeHeight(height);
+            IEntityPlayer mplayer = (IEntityPlayer) mc.getIntegratedServer().getPlayerList().getPlayerByUUID(mc.player.getUniqueID());
+            if (mplayer != null) mplayer.setEyeHeight(height);
         }
     }
 }

--- a/src/main/java/com/minelittlepony/bigpony/mod/LiteModBigPony.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/LiteModBigPony.java
@@ -92,7 +92,6 @@ public class LiteModBigPony implements BigPony, InitCompleteListener, Tickable, 
     @Override
     public void onTick(Minecraft minecraft, float partialTicks, boolean inGame, boolean clock) {
         if (settingsBind.isPressed()) {
-
             minecraft.displayGuiScreen(new GuiBigSettings(this));
         }
     }
@@ -178,10 +177,16 @@ public class LiteModBigPony implements BigPony, InitCompleteListener, Tickable, 
     }
 
     private void updateHeightDistance() {
-
-        IEntityRenderer er = (IEntityRenderer) Minecraft.getMinecraft().entityRenderer;
+		Minecraft mc = Minecraft.getMinecraft();
+		
+        IEntityRenderer er = (IEntityRenderer) mc.entityRenderer;
         er.setThirdPersonDistance(distance);
-        IEntityPlayer ep = (IEntityPlayer) Minecraft.getMinecraft().player;
+        IEntityPlayer ep = (IEntityPlayer) mc.player;
         ep.setEyeHeight(height);
+        
+        if (mc.isIntegratedServerRunning()) {
+        	IEntityPlayer mplayer = (IEntityPlayer) mc.getIntegratedServer().getPlayerList().getPlayerByUUID(mc.player.getUniqueID());
+        	if (mplayer != null) mplayer.setEyeHeight(height);
+        }
     }
 }

--- a/src/main/java/com/minelittlepony/bigpony/mod/ducks/IEntityPlayer.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/ducks/IEntityPlayer.java
@@ -3,4 +3,6 @@ package com.minelittlepony.bigpony.mod.ducks;
 public interface IEntityPlayer {
 
     void setEyeHeight(float height);
+    
+    float getHeightFactor();
 }

--- a/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayer.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayer.java
@@ -7,13 +7,15 @@ import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(EntityPlayer.class)
 @Implements(@Interface(iface = IEntityPlayer.class, prefix = "bigpony$"))
 public abstract class MixinEntityPlayer extends EntityLivingBase {
-
+	
+	public float heightFactor = 1F;
     public float eyeHeight = 1.62F;
 
     public MixinEntityPlayer(World worldIn) {
@@ -38,9 +40,13 @@ public abstract class MixinEntityPlayer extends EntityLivingBase {
             cir.setReturnValue(0.15F);
         }
     }
-
+    
     public void bigpony$setEyeHeight(float height) {
+    	this.heightFactor = height;
         this.eyeHeight = 1.62F * height;
     }
-
+    
+    public float bigpony$getHeightFactor() {
+    	return this.heightFactor;
+    }
 }

--- a/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayer.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayer.java
@@ -14,8 +14,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(EntityPlayer.class)
 @Implements(@Interface(iface = IEntityPlayer.class, prefix = "bigpony$"))
 public abstract class MixinEntityPlayer extends EntityLivingBase {
-	
-	public float heightFactor = 1F;
+
+    public float heightFactor = 1F;
     public float eyeHeight = 1.62F;
 
     public MixinEntityPlayer(World worldIn) {
@@ -40,13 +40,13 @@ public abstract class MixinEntityPlayer extends EntityLivingBase {
             cir.setReturnValue(0.15F);
         }
     }
-    
+
     public void bigpony$setEyeHeight(float height) {
-    	this.heightFactor = height;
+        this.heightFactor = height;
         this.eyeHeight = 1.62F * height;
     }
-    
+
     public float bigpony$getHeightFactor() {
-    	return this.heightFactor;
+        return this.heightFactor;
     }
 }

--- a/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayerMP.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayerMP.java
@@ -18,7 +18,7 @@ public abstract class MixinEntityPlayerMP extends EntityPlayer implements IConta
 		super(worldIn, gm);
 	}
 
-	@Inject(method = "copyFrom(Lnet/minecraft/entity/EntityPlayerMP;Z)V", at = @At("RETURN"))
+	@Inject(method = "copyFrom(Lnet/minecraft/entity/player/EntityPlayerMP;Z)V", at = @At("RETURN"))
     public void injectCopyFrom(EntityPlayerMP other, boolean keepEverything, CallbackInfo cbi) {
     	((IEntityPlayer)this).setEyeHeight(((IEntityPlayer)other).getHeightFactor());
     }

--- a/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayerMP.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayerMP.java
@@ -13,13 +13,13 @@ import com.mojang.authlib.GameProfile;
 
 @Mixin(EntityPlayerMP.class)
 public abstract class MixinEntityPlayerMP extends EntityPlayer implements IContainerListener {
-	
-    public MixinEntityPlayerMP(World worldIn, GameProfile gm) {
-		super(worldIn, gm);
-	}
 
-	@Inject(method = "copyFrom(Lnet/minecraft/entity/player/EntityPlayerMP;Z)V", at = @At("RETURN"))
+    public MixinEntityPlayerMP(World worldIn, GameProfile gm) {
+        super(worldIn, gm);
+    }
+
+    @Inject(method = "copyFrom(Lnet/minecraft/entity/player/EntityPlayerMP;Z)V", at = @At("RETURN"))
     public void injectCopyFrom(EntityPlayerMP other, boolean keepEverything, CallbackInfo cbi) {
-    	((IEntityPlayer)this).setEyeHeight(((IEntityPlayer)other).getHeightFactor());
+        ((IEntityPlayer)this).setEyeHeight(((IEntityPlayer)other).getHeightFactor());
     }
 }

--- a/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayerMP.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayerMP.java
@@ -1,0 +1,25 @@
+package com.minelittlepony.bigpony.mod.mixin;
+
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.entity.player.EntityPlayerMP;
+import net.minecraft.inventory.IContainerListener;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.minelittlepony.bigpony.mod.ducks.IEntityPlayer;
+import com.mojang.authlib.GameProfile;
+
+@Mixin(EntityPlayerMP.class)
+public abstract class MixinEntityPlayerMP extends EntityPlayer implements IContainerListener {
+	
+    public MixinEntityPlayerMP(World worldIn, GameProfile gm) {
+		super(worldIn, gm);
+	}
+
+	@Inject(method = "copyFrom(Lnet/minecraft/entity/EntityPlayerMP;Z)V", at = @At("RETURN"))
+    public void injectCopyFrom(EntityPlayerMP other, boolean keepEverything, CallbackInfo cbi) {
+    	((IEntityPlayer)this).setEyeHeight(((IEntityPlayer)other).getHeightFactor());
+    }
+}

--- a/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayerSP.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayerSP.java
@@ -1,0 +1,27 @@
+package com.minelittlepony.bigpony.mod.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.minelittlepony.bigpony.mod.ducks.IEntityPlayer;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.client.network.NetHandlerPlayClient;
+import net.minecraft.stats.RecipeBook;
+import net.minecraft.stats.StatisticsManager;
+import net.minecraft.world.World;
+
+@Mixin(EntityPlayerSP.class)
+public abstract class MixinEntityPlayerSP {
+	@Inject(
+			method = "<init>(Lnet/minecraft/client/Minecraft;Lnet/minecraft/world/World;Lnet/minecraft/client/network/NetHandlerPlayClienr;Lnet/minecraft/stats/StatisticsManager;Lnet/minecraft/stats/RecipeBook;)V",
+			at = @At(value = "RETURN"))
+	public void init(Minecraft mc, World w, NetHandlerPlayClient con, StatisticsManager stats, RecipeBook recipes, CallbackInfo cbi) {
+        if (mc.player != null && mc.player.connection == con) {
+        	IEntityPlayer pl = (IEntityPlayer)mc.player;
+        	((IEntityPlayer)this).setEyeHeight(pl.getHeightFactor());
+        }
+    }
+}

--- a/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayerSP.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayerSP.java
@@ -5,8 +5,10 @@ import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 import com.minelittlepony.bigpony.mod.ducks.IEntityPlayer;
+import com.mojang.authlib.GameProfile;
 
 import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.AbstractClientPlayer;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.network.NetHandlerPlayClient;
 import net.minecraft.stats.RecipeBook;
@@ -14,9 +16,12 @@ import net.minecraft.stats.StatisticsManager;
 import net.minecraft.world.World;
 
 @Mixin(EntityPlayerSP.class)
-public abstract class MixinEntityPlayerSP {
-	@Inject(
-			method = "<init>(Lnet/minecraft/client/Minecraft;Lnet/minecraft/world/World;Lnet/minecraft/client/network/NetHandlerPlayClienr;Lnet/minecraft/stats/StatisticsManager;Lnet/minecraft/stats/RecipeBook;)V",
+public abstract class MixinEntityPlayerSP extends AbstractClientPlayer {
+	public MixinEntityPlayerSP(World worldIn, GameProfile playerProfile) {
+		super(worldIn, playerProfile);
+	}
+
+	@Inject(method = "<init>(Lnet/minecraft/client/Minecraft;Lnet/minecraft/world/World;Lnet/minecraft/client/network/NetHandlerPlayClient;Lnet/minecraft/stats/StatisticsManager;Lnet/minecraft/stats/RecipeBook;)V",
 			at = @At(value = "RETURN"))
 	public void init(Minecraft mc, World w, NetHandlerPlayClient con, StatisticsManager stats, RecipeBook recipes, CallbackInfo cbi) {
         if (mc.player != null && mc.player.connection == con) {

--- a/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayerSP.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayerSP.java
@@ -17,16 +17,16 @@ import net.minecraft.world.World;
 
 @Mixin(EntityPlayerSP.class)
 public abstract class MixinEntityPlayerSP extends AbstractClientPlayer {
-	public MixinEntityPlayerSP(World worldIn, GameProfile playerProfile) {
-		super(worldIn, playerProfile);
-	}
+    public MixinEntityPlayerSP(World worldIn, GameProfile playerProfile) {
+        super(worldIn, playerProfile);
+    }
 
-	@Inject(method = "<init>(Lnet/minecraft/client/Minecraft;Lnet/minecraft/world/World;Lnet/minecraft/client/network/NetHandlerPlayClient;Lnet/minecraft/stats/StatisticsManager;Lnet/minecraft/stats/RecipeBook;)V",
-			at = @At(value = "RETURN"))
-	public void init(Minecraft mc, World w, NetHandlerPlayClient con, StatisticsManager stats, RecipeBook recipes, CallbackInfo cbi) {
+    @Inject(method = "<init>(Lnet/minecraft/client/Minecraft;Lnet/minecraft/world/World;Lnet/minecraft/client/network/NetHandlerPlayClient;Lnet/minecraft/stats/StatisticsManager;Lnet/minecraft/stats/RecipeBook;)V",
+            at = @At(value = "RETURN"))
+    public void init(Minecraft mc, World w, NetHandlerPlayClient con, StatisticsManager stats, RecipeBook recipes, CallbackInfo cbi) {
         if (mc.player != null && mc.player.connection == con) {
-        	IEntityPlayer pl = (IEntityPlayer)mc.player;
-        	((IEntityPlayer)this).setEyeHeight(pl.getHeightFactor());
+            IEntityPlayer pl = (IEntityPlayer)mc.player;
+            ((IEntityPlayer)this).setEyeHeight(pl.getHeightFactor());
         }
     }
 }

--- a/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinRenderLivingBase.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinRenderLivingBase.java
@@ -25,7 +25,7 @@ public abstract class MixinRenderLivingBase<T extends EntityLivingBase> extends 
             at = @At(value = "INVOKE",
                     target = "Lnet/minecraft/client/renderer/GlStateManager;scale(FFF)V",
                     shift = Shift.AFTER))
-    private void onPrepareScale(EntityLivingBase entity, float ticks, CallbackInfoReturnable ci) {
+    private void onPrepareScale(EntityLivingBase entity, float ticks, CallbackInfoReturnable<Float> ci) {
         LiteLoader.getInstance().getMod(LiteModBigPony.class).onRenderEntity(entity);
     }
 }

--- a/src/main/resources/bigpony.mixin.json
+++ b/src/main/resources/bigpony.mixin.json
@@ -6,6 +6,8 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinEntityPlayer",
+    "MixinEntityPlayerMP",
+    "MixinEntityPlayerSP",
     "MixinEntityRenderer",
     "MixinRenderLivingBase"
   ]


### PR DESCRIPTION
Whenever the player would die and respawn their chosen hight would get reset to whatever the minecraft default is. This changes it a bit so the height gets properly persisted on both the client and (integrated) server player entities, and properly copies the value over when recreating.

Note:
1. Gitignore change was because debug/run files were being encorrectly picked up by git.
2. Whitespaces were corrected to spaces as requested by @killjoy1221 