### PR TITLE
Scale the shadow with the model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 ### Gradle
 .gradle/
 build/
+run/
 
 ### JetBrains
 .idea/

--- a/src/main/java/com/minelittlepony/bigpony/mod/BigPony.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/BigPony.java
@@ -1,5 +1,6 @@
 package com.minelittlepony.bigpony.mod;
 
+//TODO: Why isn't this a subtype of IPlayerScale?
 public interface BigPony {
 
     void setScale(float xScale, float yScale, float zScale);

--- a/src/main/java/com/minelittlepony/bigpony/mod/LiteModBigPony.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/LiteModBigPony.java
@@ -13,6 +13,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.multiplayer.ServerData;
 import net.minecraft.client.network.NetHandlerPlayClient;
 import net.minecraft.client.settings.KeyBinding;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.network.INetHandler;
@@ -38,7 +39,11 @@ public class LiteModBigPony implements BigPony, InitCompleteListener, Tickable, 
     private static final String DATA = CHANNEL + "|scale";
 
     static Logger logger = LogManager.getLogger(NAME);
-
+    
+    public static LiteModBigPony instance() {
+      return LiteLoader.getInstance().getMod(LiteModBigPony.class);
+    }
+    
     @Nullable
     private SyncManager manager;
     private PlayerSizeManager sizes;
@@ -113,9 +118,9 @@ public class LiteModBigPony implements BigPony, InitCompleteListener, Tickable, 
         }
     }
 
-    public float getUpdatedShadowSize(float initial, EntityLivingBase entity) {
+    public float getUpdatedShadowSize(float initial, Entity entity) {
         if (sizes == null || !(entity instanceof IEntityPlayer)) return initial;
-        return .5f * sizes.getShadowScale(((EntityPlayer)entity));
+        return initial * sizes.getShadowScale(((EntityPlayer)entity));
     }
 
     @Override

--- a/src/main/java/com/minelittlepony/bigpony/mod/LiteModBigPony.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/LiteModBigPony.java
@@ -102,14 +102,20 @@ public class LiteModBigPony implements BigPony, InitCompleteListener, Tickable, 
         // initialize this when the player is available.
         // doing this earlier causes offline-mode to not work properly.
         this.sizes = new PlayerSizeManager(((NetHandlerPlayClient) netHandler).getGameProfile());
-        this.sizes.setScale(xScale, yScale, zScale);
+        this.sizes.setOwnScale(xScale, yScale, zScale);
 
         updateHeightDistance();
     }
 
     public void onRenderEntity(EntityLivingBase entity) {
-        if (sizes != null && entity instanceof EntityPlayer)
+        if (sizes != null && entity instanceof EntityPlayer) {
             this.sizes.onRenderPlayer((EntityPlayer) entity);
+        }
+    }
+
+    public float getUpdatedShadowSize(float initial, EntityLivingBase entity) {
+        if (sizes == null || !(entity instanceof IEntityPlayer)) return initial;
+        return .5f * sizes.getShadowScale(((EntityPlayer)entity));
     }
 
     @Override
@@ -120,7 +126,7 @@ public class LiteModBigPony implements BigPony, InitCompleteListener, Tickable, 
     @Override
     public void setScale(float xScale, float yScale, float zScale) {
         if (xScale != this.xScale || yScale != this.yScale || zScale != this.zScale) {
-            this.sizes.setScale(xScale, yScale, zScale);
+            this.sizes.setOwnScale(xScale, yScale, zScale);
 
             this.xScale = xScale;
             this.yScale = yScale;

--- a/src/main/java/com/minelittlepony/bigpony/mod/PlayerSizeManager.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/PlayerSizeManager.java
@@ -25,6 +25,9 @@ public class PlayerSizeManager {
     void onRenderPlayer(EntityPlayer player) {
         IPlayerScale size = getScale(player);
         GlStateManager.scale(size.getXScale(), size.getYScale(), size.getZScale());
+        if (player.isSneaking()) {
+            GlStateManager.translate(0, -1F + size.getYScale(), 0);
+        }
     }
 
     private PlayerScale defaultScale() {

--- a/src/main/java/com/minelittlepony/bigpony/mod/PlayerSizeManager.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/PlayerSizeManager.java
@@ -16,14 +16,14 @@ public class PlayerSizeManager {
 
     private final GameProfile clientProfile;
 
-    private Map<GameProfile, IPlayerScale> playerSizes = Maps.newHashMap();
+    private final Map<GameProfile, IPlayerScale> playerSizes = Maps.newHashMap();
 
-    public PlayerSizeManager(GameProfile clientProfile) {
-        this.clientProfile = clientProfile;
+    public PlayerSizeManager(GameProfile profile) {
+        clientProfile = profile;
     }
 
     void onRenderPlayer(EntityPlayer player) {
-        IPlayerScale size = getScale(player.getGameProfile());
+        IPlayerScale size = getScale(player);
         GlStateManager.scale(size.getXScale(), size.getYScale(), size.getZScale());
     }
 
@@ -52,13 +52,17 @@ public class PlayerSizeManager {
         return client.getPlayerInfo(uuid);
     }
 
-
-    private IPlayerScale getScale(GameProfile profile) {
-        return playerSizes.computeIfAbsent(profile, p -> defaultScale());
+    public float getShadowScale(EntityPlayer player) {
+        IPlayerScale scale = getScale(player);
+        return Math.max(scale.getXScale(), scale.getZScale());
     }
 
-    public void setScale(float xScale, float yScale, float zScale) {
-        this.playerSizes.put(clientProfile, new PlayerScale(xScale, yScale, zScale));
+    public IPlayerScale getScale(EntityPlayer player) {
+        return playerSizes.computeIfAbsent(player.getGameProfile(), p -> defaultScale());
+    }
+
+    public void setOwnScale(float xScale, float yScale, float zScale) {
+        playerSizes.put(this.clientProfile, new PlayerScale(xScale, yScale, zScale));
     }
 
 }

--- a/src/main/java/com/minelittlepony/bigpony/mod/PlayerSizeManager.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/PlayerSizeManager.java
@@ -47,9 +47,7 @@ public class PlayerSizeManager {
     @Nullable
     private NetworkPlayerInfo getPlayer(UUID uuid) {
         NetHandlerPlayClient client = Minecraft.getMinecraft().getConnection();
-        if (client == null)
-            return null;
-        return client.getPlayerInfo(uuid);
+        return client == null ? null : client.getPlayerInfo(uuid);
     }
 
     public float getShadowScale(EntityPlayer player) {
@@ -62,7 +60,7 @@ public class PlayerSizeManager {
     }
 
     public void setOwnScale(float xScale, float yScale, float zScale) {
-        playerSizes.put(this.clientProfile, new PlayerScale(xScale, yScale, zScale));
+        playerSizes.put(clientProfile, new PlayerScale(xScale, yScale, zScale));
     }
 
 }

--- a/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayer.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayer.java
@@ -26,12 +26,17 @@ public abstract class MixinEntityPlayer extends EntityLivingBase {
     }
 
     // this is for forge
-    @Redirect(method = "getEyeHeight()F", at = @At(value = "FIELD", target = "Lnet/minecraft/entity/player/EntityPlayer;eyeHeight:F", remap = false))
+    @Redirect(method = "getEyeHeight()F",
+              at = @At(value = "FIELD",
+                       target = "Lnet/minecraft/entity/player/EntityPlayer;eyeHeight:F",
+                       remap = false))
     private float redirectEyeHeight(EntityPlayer initial) {
         return eyeHeight;
     }
 
-    @Inject(method = "getEyeHeight()F", at = @At("RETURN"), cancellable = true)
+    @Inject(method = "getEyeHeight()F",
+            at = @At("RETURN"),
+            cancellable = true)
     private void fixNegativeHeights(CallbackInfoReturnable<Float> cir) {
         // prevent you from seeing under the ground when looking down.
         if (cir.getReturnValueF() < 0.15F) {
@@ -40,7 +45,7 @@ public abstract class MixinEntityPlayer extends EntityLivingBase {
     }
 
     public void bigpony$setEyeHeight(float height) {
-        this.eyeHeight = 1.62F * height;
+        eyeHeight = 1.62F * height;
     }
 
 }

--- a/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityRenderer.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityRenderer.java
@@ -17,12 +17,13 @@ public abstract class MixinEntityRenderer implements IResourceManagerReloadListe
 
     private float thirdPersonDistanceCustom;
 
-    @Redirect(method = "orientCamera(F)V", at = @At(value = "FIELD", ordinal = 0, target = DISTANCE))
+    @Redirect(method = "orientCamera(F)V",
+              at = @At(value = "FIELD", ordinal = 0, target = DISTANCE))
     private float fixCameraDistance(EntityRenderer thus) {
         return thirdPersonDistanceCustom;
     }
 
     public void bigpony$setThirdPersonDistance(float distance) {
-        this.thirdPersonDistanceCustom = 4.0F * distance;
+        thirdPersonDistanceCustom = 4.0F * distance;
     }
 }

--- a/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinRender.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinRender.java
@@ -1,0 +1,34 @@
+package com.minelittlepony.bigpony.mod.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.minelittlepony.bigpony.mod.LiteModBigPony;
+
+import net.minecraft.client.renderer.entity.Render;
+import net.minecraft.entity.Entity;
+
+@Mixin(Render.class)
+public abstract class MixinRender<T extends Entity> {
+  
+  @Shadow
+  protected float shadowSize;
+  protected float rawShadowSize = -1;
+  
+  // Redirect can't capture locals (wah-wah-waaaah)
+  @Inject(method = "renderShadow(Lnet/minecraft/entity/Entity;DDDFF)V",
+          at = @At("HEAD"))
+  private void onBeforeRenderShadow(Entity entity, double x, double y, double z, float scale, float ticks, CallbackInfo info) {
+      rawShadowSize = shadowSize;
+      shadowSize = LiteModBigPony.instance().getUpdatedShadowSize(rawShadowSize, entity);
+  }
+  
+  @Inject(method = "renderShadow(Lnet/minecraft/entity/Entity;DDDFF)V",
+          at = @At("RETURN"))
+  private void onAfterRenderShadow(Entity entity, double x, double y, double z, float scale, float ticks, CallbackInfo info) {
+      shadowSize = rawShadowSize;
+  }
+}

--- a/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinRender.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinRender.java
@@ -3,11 +3,11 @@ package com.minelittlepony.bigpony.mod.mixin;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.Redirect;
 
 import com.minelittlepony.bigpony.mod.LiteModBigPony;
 
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.entity.Entity;
 
@@ -16,19 +16,21 @@ public abstract class MixinRender<T extends Entity> {
   
   @Shadow
   protected float shadowSize;
-  protected float rawShadowSize = -1;
   
-  // Redirect can't capture locals (wah-wah-waaaah)
-  @Inject(method = "renderShadow(Lnet/minecraft/entity/Entity;DDDFF)V",
-          at = @At("HEAD"))
-  private void onBeforeRenderShadow(Entity entity, double x, double y, double z, float scale, float ticks, CallbackInfo info) {
-      rawShadowSize = shadowSize;
+  @Shadow
+  private void renderShadow(Entity entityIn, double x, double y, double z, float shadowAlpha, float partialTicks) {}
+  
+  @Redirect(method = "doRenderShadowAndFire(Lnet/minecraft/entity/Entity;DDDFF)V",
+           at = @At(value = "INVOKE",
+                    target = "Lnet/minecraft/client/renderer/entity/Render;renderShadow(Lnet/minecraft/entity/Entity;DDDFF)V"))
+  private void redirectRenderShadow(Render<T> instance, Entity entity, double x, double y, double z, float opacity, float ticks) {
+      GlStateManager.pushMatrix();
+      // The shadows render a tiny bit off the ground, so let's shift it down so as not to cut through people's legs.
+      GlStateManager.translate(0, -0.01F, 0);
+      float rawShadowSize = shadowSize;
       shadowSize = LiteModBigPony.instance().getUpdatedShadowSize(rawShadowSize, entity);
-  }
-  
-  @Inject(method = "renderShadow(Lnet/minecraft/entity/Entity;DDDFF)V",
-          at = @At("RETURN"))
-  private void onAfterRenderShadow(Entity entity, double x, double y, double z, float scale, float ticks, CallbackInfo info) {
+      renderShadow(entity, x, y, z, opacity, ticks);
       shadowSize = rawShadowSize;
+      GlStateManager.popMatrix();
   }
 }

--- a/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinRenderLivingBase.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinRenderLivingBase.java
@@ -1,7 +1,6 @@
 package com.minelittlepony.bigpony.mod.mixin;
 
 import com.minelittlepony.bigpony.mod.LiteModBigPony;
-import com.mumfrey.liteloader.core.LiteLoader;
 import net.minecraft.client.renderer.entity.Render;
 import net.minecraft.client.renderer.entity.RenderLivingBase;
 import net.minecraft.client.renderer.entity.RenderManager;
@@ -19,15 +18,12 @@ public abstract class MixinRenderLivingBase<T extends EntityLivingBase> extends 
         super(renderManager);
     }
 
-    @Inject(
-            method = "prepareScale(Lnet/minecraft/entity/EntityLivingBase;F)F",
+    @Inject(method = "prepareScale(Lnet/minecraft/entity/EntityLivingBase;F)F",
             require = 1,
             at = @At(value = "INVOKE",
                     target = "Lnet/minecraft/client/renderer/GlStateManager;scale(FFF)V",
                     shift = Shift.AFTER))
     private void onPrepareScale(EntityLivingBase entity, float ticks, CallbackInfoReturnable<Float> ci) {
-        LiteModBigPony bp = LiteLoader.getInstance().getMod(LiteModBigPony.class);
-        bp.onRenderEntity(entity);
-        this.shadowSize = bp.getUpdatedShadowSize(this.shadowSize, entity);
+        LiteModBigPony.instance().onRenderEntity(entity);
     }
 }

--- a/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinRenderLivingBase.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinRenderLivingBase.java
@@ -25,7 +25,9 @@ public abstract class MixinRenderLivingBase<T extends EntityLivingBase> extends 
             at = @At(value = "INVOKE",
                     target = "Lnet/minecraft/client/renderer/GlStateManager;scale(FFF)V",
                     shift = Shift.AFTER))
-    private void onPrepareScale(EntityLivingBase entity, float ticks, CallbackInfoReturnable ci) {
-        LiteLoader.getInstance().getMod(LiteModBigPony.class).onRenderEntity(entity);
+    private void onPrepareScale(EntityLivingBase entity, float ticks, CallbackInfoReturnable<Float> ci) {
+        LiteModBigPony bp = LiteLoader.getInstance().getMod(LiteModBigPony.class);
+        bp.onRenderEntity(entity);
+        this.shadowSize = bp.getUpdatedShadowSize(this.shadowSize, entity);
     }
 }

--- a/src/main/resources/bigpony.mixin.json
+++ b/src/main/resources/bigpony.mixin.json
@@ -7,6 +7,7 @@
   "mixins": [
     "MixinEntityPlayer",
     "MixinEntityRenderer",
+    "MixinRender",
     "MixinRenderLivingBase"
   ]
 }


### PR DESCRIPTION
Since the other PR's going nowhere, I'm going to switch it around and commit the more minor stuff first.

This just changes it so that the player's shadow matches to their model size. 

Shadow size is defined as the maximum of the width and the depth, so the shadow will always encompass the entire model but never any further.

![image](https://i.imgur.com/nGuF3ec.png)
