### PR TITLE
Apply hitbox changes to the player

### DIFF
--- a/build.number
+++ b/build.number
@@ -1,3 +1,3 @@
 #Build Number for ANT. Do not edit!
-#Tue Apr 10 19:13:04 CAT 2018
-build.number=211
+#Thu Apr 12 12:26:57 CAT 2018
+build.number=215

--- a/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayer.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayer.java
@@ -7,6 +7,7 @@ import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Implements;
 import org.spongepowered.asm.mixin.Interface;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.*;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
@@ -14,8 +15,12 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Implements(@Interface(iface = IEntityPlayer.class, prefix = "bigpony$"))
 public abstract class MixinEntityPlayer extends EntityLivingBase {
 
+    public float heightFactor = 1F;
     public float eyeHeight = 1.62F;
-
+    
+    @Shadow
+    protected abstract void updateSize();
+    
     public MixinEntityPlayer(World worldIn) {
         super(worldIn);
     }
@@ -45,7 +50,27 @@ public abstract class MixinEntityPlayer extends EntityLivingBase {
     }
 
     public void bigpony$setEyeHeight(float height) {
+        heightFactor = height;
         eyeHeight = 1.62F * height;
+        updateSize();
     }
 
+    public float bigpony$getHeightFactor() {
+        return this.heightFactor;
+    }
+    
+    @ModifyConstant(method = "updateSize()V", constant = @Constant(floatValue = 1.8F))
+    private float modifyStandingHeight(float initial) {
+        return initial * this.heightFactor;
+    }
+    
+    @ModifyConstant(method = "updateSize()V", constant = @Constant(floatValue = 1.65F))
+    private float modifySneakingHeight(float initial) {
+        return initial * this.heightFactor;
+    }
+    
+    @ModifyConstant(method = "updateSize()V", constant = @Constant(floatValue = 0.6F))
+    private float modifyWidth(float initial) {
+        return Math.max(initial * this.heightFactor, 0.3F);
+    }
 }

--- a/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayerSP.java
+++ b/src/main/java/com/minelittlepony/bigpony/mod/mixin/MixinEntityPlayerSP.java
@@ -1,0 +1,69 @@
+package com.minelittlepony.bigpony.mod.mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.*;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import com.minelittlepony.bigpony.mod.ducks.IEntityPlayer;
+import com.mojang.authlib.GameProfile;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.entity.AbstractClientPlayer;
+import net.minecraft.client.entity.EntityPlayerSP;
+import net.minecraft.client.network.NetHandlerPlayClient;
+import net.minecraft.stats.RecipeBook;
+import net.minecraft.stats.StatisticsManager;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+
+@Mixin(EntityPlayerSP.class)
+public abstract class MixinEntityPlayerSP extends AbstractClientPlayer {
+    public MixinEntityPlayerSP(World worldIn, GameProfile playerProfile) {
+        super(worldIn, playerProfile);
+    }
+
+    @Inject(method = "<init>(Lnet/minecraft/client/Minecraft;Lnet/minecraft/world/World;Lnet/minecraft/client/network/NetHandlerPlayClient;Lnet/minecraft/stats/StatisticsManager;Lnet/minecraft/stats/RecipeBook;)V",
+            at = @At(value = "RETURN"))
+    public void init(Minecraft mc, World w, NetHandlerPlayClient con, StatisticsManager stats, RecipeBook recipes, CallbackInfo cbi) {
+        if (mc.player != null && mc.player.connection == con) {
+            IEntityPlayer pl = (IEntityPlayer)mc.player;
+            ((IEntityPlayer)this).setEyeHeight(pl.getHeightFactor());
+        }
+    }
+	
+	@Inject(method = "isOpenBlockSpace(Lnet/minecraft/util/math/BlockPos;)Z",
+			at = @At("HEAD"),
+			cancellable = true)
+	private void injectIsOpenBlockSpace(BlockPos pos, CallbackInfoReturnable<Boolean> cbi) {
+		int max = (int)Math.floor(this.height);
+		
+		while (pos.getY() <= max) {
+			if (this.world.getBlockState(pos).isNormalCube()) {
+				cbi.setReturnValue(false);
+				return;
+			}
+			pos = pos.up();
+		}
+		cbi.setReturnValue(true);
+		
+		/*
+		int max = (int)Math.floor(this.height);
+		
+		List<AxisAlignedBB> boxes = new ArrayList<AxisAlignedBB>();
+		
+		AxisAlignedBB aabb = this.getCollisionBoundingBox();
+		
+		while (pos.getY() <= max) {
+			this.world.getBlockState(pos).addCollisionBoxToList(this.world, pos, aabb, boxes, this, false);
+			
+			if (!boxes.isEmpty()) {
+				cbi.setReturnValue(false);
+				return;
+			}
+			pos = pos.up();
+		}
+		cbi.setReturnValue(true);
+		 */
+    }
+}


### PR DESCRIPTION
This change adjusts the player's _actual_ hitbox to match that of their appearance through BigPony. 

It's currently only client-side, so to properly support multiplayer some changes/total rewrites to PlayerSync would be required.

[*] Unfortunately I can't build the PlayerSync plugin, so someone would have to fix that first.

[*] And unfortunately, the PlayerSync plugin is rotten with copy-pasta classes, so someone would have to _fix that too_

I have a rewrite of it stored locally, with added support for forge (non-sponge) servers, but building is still an issue.

This PR will probably stay open, mostly as a record of these above points. In the last 3 months since I originally proposed this change ( #3 ), I've yet to hear anything against or for this from @killjoy1221 so I'm assuming he's neutral on the matter.